### PR TITLE
Fix: height of modal tab container

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -29,9 +29,10 @@
   overflow-x: auto; /* Enable horizontal scrolling */
   white-space: nowrap; 
   display: block;
-  height: 70px;
+  height: 25px;
   z-index: 5;
-  background-color: lightslategray;
+  background-color: rgb(195, 203, 211);
+  flex-shrink: 0;
 }
 .wordInfoTabButtonContainer::-webkit-scrollbar {
   display: none; /* For Chrome, Safari, and Opera */ 


### PR DESCRIPTION
#11 

Without `flex-shrink: 0` :
<img width="1046" alt="Screenshot 2024-01-17 at 00 58 56" src="https://github.com/goodpals/middle-english-mouse-dictionary/assets/39569185/90959677-300f-403e-8cc1-979ce215c6a0">
<br>
With `flex-shrink: 0` :
<img width="1052" alt="Screenshot 2024-01-17 at 00 58 20" src="https://github.com/goodpals/middle-english-mouse-dictionary/assets/39569185/7f3ef60e-b5d0-47e4-9077-e75031b358ed">
