### PR TITLE
Highlight active tab in modal

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -40,7 +40,7 @@ Once HTML is injected into the browser window from a content domain script, it e
 
       const range = selection.getRangeAt(0);
       const rect = range.getBoundingClientRect(); 
-      createOrUpdateModal(event, printouts, rect);
+      createOrUpdateModal(event, printouts, Object.keys(activeWords)[0], rect);
 
       const allMatchedWordEntries = Object.values(activeWords).flatMap(entries => entries);
       createListenersForModalButtons(allMatchedWordEntries);

--- a/src/globals.js
+++ b/src/globals.js
@@ -10,14 +10,14 @@
  * @global
  * @constant
  */
-const SIDEBAR_ID = '_MEMD_sidebar'; 
+const SIDEBAR_ID = '_MEMD_sidebar_'; 
 
 /**
  * @global
  * @constant
  * this is the X close button on the sidebar
 */
-const SIDEBAR_CLOSE_BUTTON_ID = '_MEMD_delSidebar';
+const SIDEBAR_CLOSE_BUTTON_ID = '_MEMD_delSidebar_';
 
 /**
  * @global
@@ -31,14 +31,21 @@ const MODAL_ID = '_MEMD_yeFloatingeWindowe';
  * @constant
  * Different words the user highlights, displayed in the modal
 */
-const MODAL_WORDTAB_ID_PREFIX = '_MEMD_TAB_BTN'; 
+const MODAL_WORDTAB_BUTTON_PREFIX = '_MEMD_TAB_BTN_';
+
+/**
+ * @global
+ * @constant
+ * Content of the word tabs
+*/
+const MODAL_WORDTAB_CONTENT_PREFIX = '_MEMD_TAB_CONTENT_';
 
 /**
  * @global
  * @constant
  * Button to add to the user list (displayed in the sidebar)
  */
-const MODAL_ADDWORD_BUTTON_ID_PREFIX = '_MEMD_ADD_BTN';
+const MODAL_ADDWORD_BUTTON_ID_PREFIX = '_MEMD_ADD_BTN_';
 
 
 

--- a/src/modal.js
+++ b/src/modal.js
@@ -18,10 +18,11 @@
 
 /**
  * @param {MouseEvent} event contains co-ordinates for your mouse position etc.
- * @param {Object<string, string} content a word and its HTMLized dictionary info
+ * @param {Object<string, string>} content a word and its HTMLized dictionary info
+ * @param {string} firstWord the first word in the list
  * @param {DOMRect} rect position data for adjusting the popup modal location
  */
-async function createModal(event, content, rect) {
+async function createModal(event, content, firstWord, rect) {
   const context = "createModal";
   removeListenersForTabButtons();
 
@@ -48,7 +49,7 @@ async function createModal(event, content, rect) {
   await promiseNextFrame();
 
   createTabButtonsWithListeners(content, modal, buttonContainer);
-  showRequestedWordTab(presentTabButtonListeners[0]);
+  showRequestedWordTab(firstWord);
   repositionModal(modal);
 }
 
@@ -118,7 +119,7 @@ function getModalViewportPosition(modal) {
 
 
 /**
- * @param {Object<string, string} content a word and its HTMLized dictionary info
+ * @param {Object<string, string>} content a word and its HTMLized dictionary info
 */
 function createTabButtonsWithListeners(content, modal, buttonContainer) {
   const context = "createTabButtonsWithListeners";
@@ -126,12 +127,12 @@ function createTabButtonsWithListeners(content, modal, buttonContainer) {
 
   Object.keys(content).forEach((key) => {
     let button = document.createElement('button');
-    const targetId = `${MODAL_WORDTAB_ID_PREFIX}${key}`; // must be const'd
+    const targetId = `${MODAL_WORDTAB_CONTENT_PREFIX}${key}`; // must be const'd
 
-    button.id = targetId;
+    button.id = `${MODAL_WORDTAB_BUTTON_PREFIX}${key}`;
     button.className = 'wordInfoTabButton';
     button.textContent = key;
-    button.addEventListener('click', (event) => showRequestedWordTab(targetId));
+    button.addEventListener('click', (event) => showRequestedWordTab(key));
 
     try {
       buttonContainer.appendChild(button);
@@ -144,16 +145,20 @@ function createTabButtonsWithListeners(content, modal, buttonContainer) {
 
 
 function showRequestedWordTab(targetId) {
-  const targetElement = document.getElementById(targetId);
+  const targetElement = document.getElementById(`${MODAL_WORDTAB_CONTENT_PREFIX}${targetId}`);
   const otherElements = document.querySelectorAll('.wordInfoTab');
   otherElements.forEach(element => element.style.display = "none");
   targetElement.style.display = "block";
+  const buttons = document.querySelectorAll('.wordInfoTabButton');
+  buttons.forEach(button => button.className = 'wordInfoTabButton');
+  const button = document.getElementById(`${MODAL_WORDTAB_BUTTON_PREFIX}${targetId}`);
+  button.className = 'wordInfoTabButton active';
 }
 
 
 function removeListenersForTabButtons() {
   for (const id of presentTabButtonListeners) {
-    const button = document.querySelector(`#${MODAL_WORDTAB_ID_PREFIX}${id}`); // note the hash
+    const button = document.querySelector(`#${MODAL_WORDTAB_BUTTON_PREFIX}${id}`); // note the hash
     if (button) button.removeEventListener('click', (event) => showRequestedWordTab(targetId));
   }
   clearTabButtonListeners();
@@ -162,15 +167,15 @@ function removeListenersForTabButtons() {
 
 
 /**
- * @param {Object<string, string} content a word and its HTMLized dictionary info
+ * @param {Object<string, string>} content a word and its HTMLized dictionary info
  * @param {*} modal the modal to which such HTML text will be applied
  */
 function buildWordInfoTabSections(content, modal) {
   const context = "buildWordInfoTabSections";
   Object.entries(content).forEach(([key, HTMLText]) => {
     let elem = document.createElement('div');
-    const id = `${MODAL_WORDTAB_ID_PREFIX}${key}`;
-    presentTabButtonListeners.push(id);
+    const id = `${MODAL_WORDTAB_CONTENT_PREFIX}${key}`;
+    presentTabButtonListeners.push(`${MODAL_WORDTAB_BUTTON_PREFIX}${key}`);
 
     elem.id = id;
     elem.className = 'wordInfoTab';
@@ -226,14 +231,16 @@ function deleteListenersForModalButtons() {
 /**
  * @param {MouseEvent} event 
  * @param {string} content 
+ * @param {string} firstWord the first word in the list
+ * @param {DOMRect} rect position data for adjusting the popup modal location
  */
-function createOrUpdateModal(event, content, rect) {
+function createOrUpdateModal(event, content, firstWord, rect) {
   let modal = findModal();
   if (modal == null || modal == undefined) {
-    createModal(event, content, rect);
+    createModal(event, content, firstWord, rect);
   } else {
     modal.remove();
-    createModal(event, content, rect);
+    createModal(event, content, firstWord, rect);
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -78,6 +78,10 @@ Its class is wordInfoModalPopup.
   font-family: Arial, Helvetica, sans-serif;
 }
 
+.wordInfoTabButton.active {
+  background-color: deepskyblue;
+}
+
 /* TODO: implement a + in the button similar to the sidebar close button. */
 .modalButton {
   height: 24px;


### PR DESCRIPTION
Like so:

![Screenshot 2024-05-11 at 21 25 57](https://github.com/goodpals/middle-english-mouse-dictionary/assets/2500696/5cf9f8b0-92b6-450f-8ef1-9c3a156165e4)

Also includes a change to the IDs of elements: previously, the buttons and tabs for each word shared the same element ID, and a lot of things depended on this. So I changed that and all the things that depended on it.